### PR TITLE
Update config.yaml to alpha

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ keywords: 'software, data, lesson, The Carpentries'
 
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable
-life_cycle: 'beta'
+life_cycle: 'alpha'
 
 # License of the lesson materials (recommended CC-BY 4.0)
 license: 'CC-BY 4.0'


### PR DESCRIPTION
Changing the lesson config from beta to alpha until maintainers have a chance to meet with [LC Curriculum Advisory Committee](https://github.com/LibraryCarpentry/curriculum-advisors) to discuss. This addresses this [librarycarpentry.org issue](https://github.com/LibraryCarpentry/librarycarpentry.org/issues/51).