### PR TITLE
Remove note to check MAC shortcut in 05-intro_to_querying.md

### DIFF
--- a/episodes/05-intro_to_querying.md
+++ b/episodes/05-intro_to_querying.md
@@ -88,7 +88,7 @@ SELECT * WHERE {
 ```
 
 *Hint* It is enough to start typing "SELECT" and then use the auto-completion with
-Ctrl+Space. % TODO what is this for on a Mac?
+Ctrl+Space.
 
 Inside the parenthesis you can then place the statements describing the graph pattern
 you are looking for.


### PR DESCRIPTION
Remove the note about checking Mac shortcuts after verifying that CTRL+SPACE is correct on both Windows and Mac.
