### PR TITLE
Replace FIXME placeholder title on reference page

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -1,5 +1,5 @@
 ---
-title: 'FIXME'
+title: 'Reference'
 ---
 
 ## Glossary


### PR DESCRIPTION
Closes #79

## Summary

The reference page (`learners/reference.md`) had `title: 'FIXME'` in its frontmatter, left over from the Carpentries lesson template. Since the workbench renders a page's `title` as its label in the navigation menu, the Reference entry showed up as "FIXME" on the rendered site.

Replace the placeholder with "Reference" so the menu label matches the page.

## Testing

Frontmatter-only change. No site rebuild was run locally, but the title field is the only input the workbench uses for the menu label (confirmed by the page's rendering at https://librarycarpentry.github.io/lc-wikidata/reference.html).

